### PR TITLE
Add type namespace, caveat parameter name

### DIFF
--- a/mapSchema.go
+++ b/mapSchema.go
@@ -127,15 +127,17 @@ func mapUserSetChild(children []*corev1.SetOperation_Child) []*UserSet {
 func mapRelationType(relationType *corev1.AllowedRelation) *RelationType {
 	name, ns := splitNamespace(relationType.Namespace)
 
-	Relation, ok := relationType.RelationOrWildcard.(*corev1.AllowedRelation_Relation)
 	var relationName string
-	if !ok {
-		relationName = "*"
-	} else {
-		relationName = Relation.Relation
+	switch v := relationType.RelationOrWildcard.(type) {
+	case *corev1.AllowedRelation_Relation:
+		relationName = v.Relation
+
 		if relationName == "..." {
 			relationName = ""
 		}
+
+	case *corev1.AllowedRelation_PublicWildcard_:
+		relationName = "*"
 	}
 
 	caveat := relationType.RequiredCaveat

--- a/mapSchema.go
+++ b/mapSchema.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/authzed/spicedb/pkg/namespace"
-	"github.com/authzed/spicedb/pkg/proto/core/v1"
-	"github.com/authzed/spicedb/pkg/proto/impl/v1"
+	corev1 "github.com/authzed/spicedb/pkg/proto/core/v1"
+	implv1 "github.com/authzed/spicedb/pkg/proto/impl/v1"
 )
 
 func mapDefinition(def *corev1.NamespaceDefinition) (*Definition, error) {
@@ -158,9 +158,10 @@ func getMetadataComments(metaData *corev1.Metadata) string {
 }
 
 func mapCaveat(caveat *corev1.CaveatDefinition) *Caveat {
-	var parameters []string
-	for _, t := range caveat.ParameterTypes {
-		parameters = append(parameters, t.TypeName)
+	parameters := map[string]string{}
+
+	for key, value := range caveat.ParameterTypes {
+		parameters[key] = value.TypeName
 	}
 
 	return &Caveat{
@@ -191,9 +192,9 @@ type RelationType struct {
 }
 
 type Permission struct {
-	Name    string   `json:"name"`
+	Name    string `json:"name"`
 	UserSet *UserSet `json:"userSet"`
-	Comment string   `json:"comment,omitempty"`
+	Comment string `json:"comment,omitempty"`
 }
 
 type UserSet struct {
@@ -204,9 +205,9 @@ type UserSet struct {
 }
 
 type Caveat struct {
-	Name       string   `json:"name"`
-	Parameters []string `json:"parameters"`
-	Comment    string   `json:"comment,omitempty"`
+	Name       string            `json:"name"`
+	Parameters map[string]string `json:"parameters"`
+	Comment    string            `json:"comment,omitempty"`
 }
 
 type Schema struct {


### PR DESCRIPTION
I'm generating some csharp with this and noticed some of the data was missing.

Also changed the type cast to a switch on `relationType.RelationOrWildcard.(type)`, since it's slightly more explicit.